### PR TITLE
Clean up mobile auth routes and fix endpoint naming

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,7 @@ Mobile apps use the Hono API (`/api/v1/auth/*`) instead of calling Better Auth e
    }
    ```
 
-2. **GET `/api/v1/auth/sign-in`** - Exchange credentials for JWT tokens
+2. **POST `/api/v1/auth/sign-in`** - Exchange credentials for JWT tokens
    - Headers: `Authorization: Basic <base64(email:password)>`
    - Returns: `{accessToken, refreshToken}`
 
@@ -163,7 +163,7 @@ Mobile apps use the Hono API (`/api/v1/auth/*`) instead of calling Better Auth e
    }
    ```
 
-4. **POST `/api/v1/auth/forget-password`** - Send password reset email
+4. **POST `/api/v1/auth/forgot-password`** - Send password reset email
 
    ```json
    {
@@ -186,7 +186,7 @@ Mobile apps use the Hono API (`/api/v1/auth/*`) instead of calling Better Auth e
 
 **Locale Handling for Mobile:**
 
-All email-sending endpoints (`sign-up`, `send-verification-email`, `forget-password`) extract locale from the `Accept-Language` header:
+All email-sending endpoints (`sign-up`, `send-verification-email`, `forgot-password`) extract locale from the `Accept-Language` header:
 
 ```text
 Mobile App → Headers: Accept-Language: ja

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,7 +8,7 @@ const authMiddleware = defineMiddleware(async (context, next) => {
     return next();
   }
 
-  // Extract locale using fallback chain: cookie > URL path > Accept-Language > default
+  // Extract locale for auth instance (used if auth triggers emails, e.g. account deletion)
   const url = new URL(context.request.url);
   const locale = getLocaleFromRequest(url, context.cookies, context.request.headers);
 

--- a/tests/integration/auth-routes-locale.test.ts
+++ b/tests/integration/auth-routes-locale.test.ts
@@ -1,0 +1,232 @@
+import {describe, it, expect, beforeAll, beforeEach, vi} from "vitest";
+import {env} from "cloudflare:test";
+import {Hono} from "hono";
+import authRoutes from "@/lib/hono/routes/auth-routes";
+import type {APIRouteContext} from "@/pages/api/[...path]";
+
+// Track createAuth calls to verify locale parameter
+const createAuthSpy = vi.fn().mockReturnValue({
+  api: {
+    signUpEmail: vi.fn().mockResolvedValue({id: "new-user"}),
+    sendVerificationEmail: vi.fn().mockResolvedValue({status: true}),
+    requestPasswordReset: vi.fn().mockResolvedValue({status: true}),
+    resetPassword: vi.fn().mockResolvedValue({status: true}),
+    signInTokens: vi.fn().mockResolvedValue({token: "jwt", user: {}}),
+    refreshTokens: vi.fn().mockResolvedValue({token: "refreshed"}),
+    revokeTokens: vi.fn().mockResolvedValue({success: true})
+  }
+});
+
+vi.mock("@/lib/auth", () => ({
+  createAuth: (...args: unknown[]) => createAuthSpy(...args)
+}));
+
+// Mock authMiddleware to set auth from the spy (for non-locale routes like sign-in)
+vi.mock("@/lib/hono/middleware/authMiddleware", () => ({
+  authMiddleware: vi.fn(() => async (c: any, next: any) => {
+    c.set("auth", createAuthSpy(env, "en"));
+    await next();
+  })
+}));
+
+describe("Auth Routes Locale Integration Tests", () => {
+  let app: Hono<APIRouteContext>;
+
+  beforeAll(async () => {
+    app = new Hono<APIRouteContext>();
+
+    // Set up env middleware so routes can access c.get("env")
+    app.use("*", async (c, next) => {
+      c.set("env", env as any);
+      await next();
+    });
+
+    // Set up auth middleware for non-locale routes
+    const {authMiddleware} = await import(
+      "@/lib/hono/middleware/authMiddleware"
+    );
+    app.use("*", authMiddleware(env as any));
+
+    app.route("/auth", authRoutes);
+  });
+
+  beforeEach(() => {
+    createAuthSpy.mockClear();
+  });
+
+  describe("POST /auth/sign-up", () => {
+    const body = {
+      email: "test@example.com",
+      password: "password123",
+      name: "Test User"
+    };
+
+    it("should pass Japanese locale to createAuth when Accept-Language is ja", async () => {
+      await app.request("/auth/sign-up", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Accept-Language": "ja"
+        },
+        body: JSON.stringify(body)
+      });
+
+      // The route calls createAuth directly (not the middleware one)
+      // Find the call with "ja" locale
+      const routeCall = createAuthSpy.mock.calls.find(
+        (call: unknown[]) => call[1] === "ja"
+      );
+      expect(routeCall).toBeDefined();
+      expect(routeCall![1]).toBe("ja");
+    });
+
+    it("should pass English locale to createAuth when Accept-Language is en-US", async () => {
+      await app.request("/auth/sign-up", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Accept-Language": "en-US"
+        },
+        body: JSON.stringify(body)
+      });
+
+      const routeCall = createAuthSpy.mock.calls.find(
+        (call: unknown[]) => call[1] === "en"
+      );
+      expect(routeCall).toBeDefined();
+      expect(routeCall![1]).toBe("en");
+    });
+
+    it("should default to en when Accept-Language is unsupported", async () => {
+      await app.request("/auth/sign-up", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Accept-Language": "fr-FR"
+        },
+        body: JSON.stringify(body)
+      });
+
+      // All createAuth calls should use "en" (default) since "fr" isn't supported
+      const routeCall = createAuthSpy.mock.calls.find(
+        (call: unknown[]) => call[1] !== "en"
+      );
+      expect(routeCall).toBeUndefined();
+    });
+
+    it("should default to en when no Accept-Language header is sent", async () => {
+      await app.request("/auth/sign-up", {
+        method: "POST",
+        headers: {"Content-Type": "application/json"},
+        body: JSON.stringify(body)
+      });
+
+      const allLocales = createAuthSpy.mock.calls.map(
+        (call: unknown[]) => call[1]
+      );
+      expect(allLocales).toContain("en");
+      expect(allLocales).not.toContain("ja");
+    });
+
+    it("should pick first supported locale from multi-value header", async () => {
+      await app.request("/auth/sign-up", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Accept-Language": "fr, ja;q=0.9, en;q=0.8"
+        },
+        body: JSON.stringify(body)
+      });
+
+      const routeCall = createAuthSpy.mock.calls.find(
+        (call: unknown[]) => call[1] === "ja"
+      );
+      expect(routeCall).toBeDefined();
+    });
+  });
+
+  describe("POST /auth/send-verification-email", () => {
+    it("should pass Japanese locale to createAuth", async () => {
+      await app.request("/auth/send-verification-email", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Accept-Language": "ja-JP"
+        },
+        body: JSON.stringify({email: "test@example.com"})
+      });
+
+      const routeCall = createAuthSpy.mock.calls.find(
+        (call: unknown[]) => call[1] === "ja"
+      );
+      expect(routeCall).toBeDefined();
+    });
+
+    it("should default to en without Accept-Language", async () => {
+      await app.request("/auth/send-verification-email", {
+        method: "POST",
+        headers: {"Content-Type": "application/json"},
+        body: JSON.stringify({email: "test@example.com"})
+      });
+
+      const allLocales = createAuthSpy.mock.calls.map(
+        (call: unknown[]) => call[1]
+      );
+      expect(allLocales.every((l: string) => l === "en")).toBe(true);
+    });
+  });
+
+  describe("POST /auth/forgot-password", () => {
+    it("should pass Japanese locale to createAuth", async () => {
+      await app.request("/auth/forgot-password", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Accept-Language": "ja"
+        },
+        body: JSON.stringify({email: "test@example.com"})
+      });
+
+      const routeCall = createAuthSpy.mock.calls.find(
+        (call: unknown[]) => call[1] === "ja"
+      );
+      expect(routeCall).toBeDefined();
+    });
+
+    it("should default to en for unsupported locale", async () => {
+      await app.request("/auth/forgot-password", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Accept-Language": "de-DE"
+        },
+        body: JSON.stringify({email: "test@example.com"})
+      });
+
+      const routeCall = createAuthSpy.mock.calls.find(
+        (call: unknown[]) => call[1] !== "en"
+      );
+      expect(routeCall).toBeUndefined();
+    });
+  });
+
+  describe("POST /auth/reset-password (non-locale route)", () => {
+    it("should use middleware auth, not create locale-specific auth", async () => {
+      await app.request("/auth/reset-password", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Accept-Language": "ja"
+        },
+        body: JSON.stringify({newPassword: "new123", token: "reset-token"})
+      });
+
+      // reset-password uses c.get("auth") from middleware, not createAuth with locale
+      // So no createAuth call should have "ja" as the locale
+      const jaCall = createAuthSpy.mock.calls.find(
+        (call: unknown[]) => call[1] === "ja"
+      );
+      expect(jaCall).toBeUndefined();
+    });
+  });
+});

--- a/tests/integration/auth-routes.test.ts
+++ b/tests/integration/auth-routes.test.ts
@@ -55,14 +55,14 @@ describe("Auth Routes Integration Tests", () => {
     app.route("/auth", authRoutes);
   });
 
-  describe("GET /auth/sign-in", () => {
+  describe("POST /auth/sign-in", () => {
     it("should return JWT token and user data with valid basic auth", async () => {
       const basicToken = btoa("test@example.com:password123");
 
       const res = await app.request(
         "/auth/sign-in",
         {
-          method: "GET",
+          method: "POST",
           headers: {
             Authorization: `Basic ${basicToken}`
           }
@@ -83,7 +83,7 @@ describe("Auth Routes Integration Tests", () => {
       const res = await app.request(
         "/auth/sign-in",
         {
-          method: "GET"
+          method: "POST"
         },
         env
       );
@@ -96,7 +96,7 @@ describe("Auth Routes Integration Tests", () => {
       const res = await app.request(
         "/auth/sign-in",
         {
-          method: "GET",
+          method: "POST",
           headers: {
             Authorization: "Invalid auth header"
           }

--- a/tests/unit/utils/i18n.test.ts
+++ b/tests/unit/utils/i18n.test.ts
@@ -1,0 +1,130 @@
+import {describe, it, expect} from "vitest";
+import {
+  getLanguageFromHeaders,
+  getLocaleFromUrl,
+  localizeUrl,
+  getLocaleFromRequest
+} from "@/i18n/utils";
+
+describe("i18n Utilities", () => {
+  describe("getLanguageFromHeaders", () => {
+    it("should return locale from simple Accept-Language header", () => {
+      const headers = new Headers({"Accept-Language": "ja"});
+      expect(getLanguageFromHeaders(headers)).toBe("ja");
+    });
+
+    it("should extract base language from region-qualified header", () => {
+      const headers = new Headers({"Accept-Language": "ja-JP"});
+      expect(getLanguageFromHeaders(headers)).toBe("ja");
+    });
+
+    it("should return first supported locale from multi-value header", () => {
+      const headers = new Headers({"Accept-Language": "fr, ja;q=0.9, en;q=0.8"});
+      expect(getLanguageFromHeaders(headers)).toBe("ja");
+    });
+
+    it("should return en when it appears first and is supported", () => {
+      const headers = new Headers({"Accept-Language": "en-US, ja;q=0.5"});
+      expect(getLanguageFromHeaders(headers)).toBe("en");
+    });
+
+    it("should return null when no supported locale matches", () => {
+      const headers = new Headers({"Accept-Language": "fr, de, es"});
+      expect(getLanguageFromHeaders(headers)).toBeNull();
+    });
+
+    it("should return null when header is missing", () => {
+      const headers = new Headers();
+      expect(getLanguageFromHeaders(headers)).toBeNull();
+    });
+  });
+
+  describe("getLocaleFromUrl", () => {
+    it("should extract locale from URL path", () => {
+      expect(getLocaleFromUrl("/ja/dashboard")).toBe("ja");
+    });
+
+    it("should return default locale for unsupported language prefix", () => {
+      expect(getLocaleFromUrl("/fr/dashboard")).toBe("en");
+    });
+
+    it("should return default locale for root path", () => {
+      expect(getLocaleFromUrl("/")).toBe("en");
+    });
+
+    it("should return en when en is the prefix", () => {
+      expect(getLocaleFromUrl("/en/settings")).toBe("en");
+    });
+  });
+
+  describe("localizeUrl", () => {
+    it("should add locale prefix to a plain path", () => {
+      expect(localizeUrl("/dashboard", "ja")).toBe("/ja/dashboard");
+    });
+
+    it("should replace existing locale prefix", () => {
+      expect(localizeUrl("/en/dashboard", "ja")).toBe("/ja/dashboard");
+    });
+
+    it("should default to en for unsupported locale", () => {
+      expect(localizeUrl("/dashboard", "fr" as any)).toBe("/en/dashboard");
+    });
+
+    it("should handle root path", () => {
+      expect(localizeUrl("/", "ja")).toBe("/ja");
+    });
+
+    it("should default to en when no locale is provided", () => {
+      expect(localizeUrl("/dashboard")).toBe("/en/dashboard");
+    });
+  });
+
+  describe("getLocaleFromRequest", () => {
+    function makeCookies(value?: string) {
+      return {
+        get: (name: string) =>
+          name === "preferred_lang" && value ? {value} : undefined
+      };
+    }
+
+    it("should prioritize cookie over everything else", () => {
+      const url = new URL("https://example.com/en/dashboard");
+      const headers = new Headers({"Accept-Language": "en"});
+      const cookies = makeCookies("ja");
+
+      expect(getLocaleFromRequest(url, cookies, headers)).toBe("ja");
+    });
+
+    it("should fall back to URL path when no cookie is set", () => {
+      const url = new URL("https://example.com/ja/dashboard");
+      const headers = new Headers({"Accept-Language": "en"});
+      const cookies = makeCookies();
+
+      expect(getLocaleFromRequest(url, cookies, headers)).toBe("ja");
+    });
+
+    it("should fall back to Accept-Language when no cookie or URL locale", () => {
+      const url = new URL("https://example.com/dashboard");
+      const headers = new Headers({"Accept-Language": "ja-JP"});
+      const cookies = makeCookies();
+
+      expect(getLocaleFromRequest(url, cookies, headers)).toBe("ja");
+    });
+
+    it("should return default locale when nothing matches", () => {
+      const url = new URL("https://example.com/dashboard");
+      const headers = new Headers();
+      const cookies = makeCookies();
+
+      expect(getLocaleFromRequest(url, cookies, headers)).toBe("en");
+    });
+
+    it("should ignore invalid cookie values", () => {
+      const url = new URL("https://example.com/ja/page");
+      const headers = new Headers();
+      const cookies = makeCookies("fr");
+
+      expect(getLocaleFromRequest(url, cookies, headers)).toBe("ja");
+    });
+  });
+});


### PR DESCRIPTION
- Add centralized error handling with authRoutes.onError()
- Add validateBody() helper for consistent input validation
- Remove repetitive try-catch blocks (~100 lines removed)
- Remove unnecessary dynamic imports (use regular import)
- Remove unnecessary asResponse: true
- Use middleware auth instance for reset-password (doesn't send emails)
- Fix endpoint naming: /forget-password → /forgot-password
- Fix HTTP method: GET /sign-in → POST /sign-in
- Add section comments for better code organization
- Update CLAUDE.md to reflect corrected endpoints
- Improve middleware comment clarity

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>