### PR TITLE
Configure Better Auth to generate uppercase UUIDs as entity IDs

### DIFF
--- a/src/lib/auth-config.ts
+++ b/src/lib/auth-config.ts
@@ -6,6 +6,7 @@ import {jwt} from "better-auth/plugins";
 
 // WARNING: This file is only used to generate the auth schema since getting a hold of D1 database is not possible outside of request context.
 export const auth = betterAuth({
+  generateId: () => crypto.randomUUID().toUpperCase(),
   database: drizzleAdapter(
     {},
     {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -17,6 +17,7 @@ export function createAuth(env: Env, locale: string = "en") {
   return betterAuth({
     secret: env.BETTER_AUTH_SECRET,
     baseURL: env.BETTER_AUTH_BASE_URL,
+    generateId: () => crypto.randomUUID().toUpperCase(),
     trustedOrigins: [env.BETTER_AUTH_BASE_URL],
     database: drizzleAdapter(createDrizzle(env.DB), {provider: "sqlite"}),
     user: {


### PR DESCRIPTION
## Summary

- Adds `generateId: () => crypto.randomUUID().toUpperCase()` to both the runtime auth instance (`auth.ts`) and the schema generation config (`auth-config.ts`)
- Ensures all Better Auth-managed entity IDs (users, sessions, accounts, etc.) are generated as uppercase UUIDs

## Test plan

- [ ] Sign up a new user and verify the generated user ID is an uppercase UUID
- [ ] Confirm sessions and accounts also receive uppercase UUID IDs
- [ ] Run `pnpm better-auth:schema` to ensure schema generation still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)